### PR TITLE
Fixing Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,14 @@
 CMakeCache.txt
 CMakeFiles
 build
+cmake-build-debug
+cmake-build-release
+out
 
 # Editor config
 .vscode
+.idea
+.vs
 
 # Profiling Output
 QuasarProfile-*

--- a/Quasar/CMakeLists.txt
+++ b/Quasar/CMakeLists.txt
@@ -172,20 +172,11 @@ endif()
 # ---------------------------------------
 # ---------- Post Build Events ----------
 # ---------------------------------------
-# Per-platform commands
-if(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Linux" OR ${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Darwin")
-  set(COPY_DIR_COMMAND cp -r)
-elseif(${CMAKE_HOST_SYSTEM_NAME} STREQUAL "Windows")
-  set(COPY_DIR_COMMAND copy /y)
-else()
-  message(FATAL_ERROR "Host platform not supported!")
-endif()
-
 # Copy assets folder to the directory containing the binaries of the program that uses quasar
 add_custom_command(
   TARGET quasar
   POST_BUILD
-  COMMAND ${COPY_DIR_COMMAND} "${CMAKE_CURRENT_SOURCE_DIR}/assets" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}"
+  COMMAND ${CMAKE_COMMAND} -E copy_directory "${CMAKE_CURRENT_SOURCE_DIR}/assets" "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/assets"
   VERBATIM
 )
 # -------------------------------------------

--- a/Quasar/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Quasar/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -9,7 +9,7 @@
 namespace Quasar
 {
 
-    void openGLMesssageCallback(
+    void openGLMessageCallback(
         unsigned int source,
         unsigned int type,
         unsigned int id,
@@ -49,7 +49,7 @@ namespace Quasar
 #ifdef QS_DEBUG
         glEnable(GL_DEBUG_OUTPUT);
         glEnable(GL_DEBUG_OUTPUT_SYNCHRONOUS);
-        glDebugMessageCallback(openGLMesssageCallback, nullptr);
+        glDebugMessageCallback((GLDEBUGPROC)openGLMessageCallback, nullptr);
 
         glDebugMessageControl(GL_DONT_CARE, GL_DONT_CARE, GL_DEBUG_SEVERITY_NOTIFICATION, 0, nullptr, GL_FALSE);
 #endif

--- a/Quasar/src/Platform/Windows/WindowsPlatformUtils.cpp
+++ b/Quasar/src/Platform/Windows/WindowsPlatformUtils.cpp
@@ -1,3 +1,4 @@
+#include <Windows.h>
 #include "Quasar/Utils/PlatformUtils.hpp"
 
 #include <commdlg.h>
@@ -10,16 +11,17 @@
 namespace Quasar
 {
 
-    std::optional<std::string> FileDialogs::openFile(const std::pair<std::string, std::string> &filter)
+    std::string FileDialogs::openFile(const std::pair<std::string, std::string> &filter)
     {
-        const char *filterStr = (filter.first + "\0" + filter.second + "\0").c_str();
+        std::string str = filter.first + '\0' + filter.second + '\0';
+        const char *filterStr = str.c_str();
 
         OPENFILENAMEA ofn;
         CHAR szFile[260] = { 0 };
         CHAR currentDir[256] = { 0 };
         ZeroMemory(&ofn, sizeof(OPENFILENAME));
         ofn.lStructSize = sizeof(OPENFILENAME);
-        ofn.hwndOwner = glfwGetWin32Window((GLFWwindow *)Application::Get().GetWindow().GetNativeWindow());
+        ofn.hwndOwner = glfwGetWin32Window((GLFWwindow *)Application::get().getWindow().getNativeWindow());
         ofn.lpstrFile = szFile;
         ofn.nMaxFile = sizeof(szFile);
         if (GetCurrentDirectoryA(256, currentDir))
@@ -34,19 +36,20 @@ namespace Quasar
         {
             return ofn.lpstrFile;
         }
-        return std::nullopt;
+        return "";
     }
 
-    std::optional<std::string> FileDialogs::saveFile(const std::pair<std::string, std::string> &filter)
+    std::string FileDialogs::saveFile(const std::pair<std::string, std::string> &filter)
     {
-        const char *filterStr = (filter.first + "\0" + filter.second + "\0").c_str();    
+        std::string str = filter.first + '\0' + filter.second + '\0';
+        const char *filterStr = str.c_str();
 
         OPENFILENAMEA ofn;
         CHAR szFile[260] = { 0 };
         CHAR currentDir[256] = { 0 };
         ZeroMemory(&ofn, sizeof(OPENFILENAME));
         ofn.lStructSize = sizeof(OPENFILENAME);
-        ofn.hwndOwner = glfwGetWin32Window((GLFWwindow *)Application::Get().GetWindow().GetNativeWindow());
+        ofn.hwndOwner = glfwGetWin32Window((GLFWwindow *)Application::get().getWindow().getNativeWindow());
         ofn.lpstrFile = szFile;
         ofn.nMaxFile = sizeof(szFile);
         if (GetCurrentDirectoryA(256, currentDir))
@@ -58,13 +61,13 @@ namespace Quasar
         ofn.Flags = OFN_PATHMUSTEXIST | OFN_OVERWRITEPROMPT | OFN_NOCHANGEDIR;
 
         // Sets the default extension by extracting it from the filter
-        ofn.lpstrDefExt = strchr(filter, '\0') + 1;
+        ofn.lpstrDefExt = strchr(filterStr, '\0') + 1;
 
         if (GetSaveFileNameA(&ofn) == TRUE)
         {
-			return ofn.lpstrFile;
+            return ofn.lpstrFile;
         }
-        return std::nullopt;
+        return "";
     }
 
 } // namespace Quasar

--- a/Quasar/src/Quasar/System/FileSystem.cpp
+++ b/Quasar/src/Quasar/System/FileSystem.cpp
@@ -7,12 +7,12 @@ namespace Quasar
     
     std::string FileSystem::getAbsolutePath(std::string_view filepath)
     {
-        return (s_CurrentPath / filepath);
+        return (s_CurrentPath / filepath).string();
     }
     
     std::string FileSystem::getAssetPath(std::string_view assetPath) 
     {
-        return (s_CurrentPath / "assets" / assetPath);
+        return (s_CurrentPath / "assets" / assetPath).string();
     }
 
 } // namespace Quasar

--- a/Quasar/src/Quasar/Utils/PlatformUtils.hpp
+++ b/Quasar/src/Quasar/Utils/PlatformUtils.hpp
@@ -2,7 +2,6 @@
 
 #include <string>
 #include <utility>
-#include <optional>
 
 namespace Quasar
 {
@@ -10,8 +9,8 @@ namespace Quasar
     class FileDialogs
     {
     public:
-        static std::optional<std::string> openFile(const std::pair<std::string, std::string> &filter); // "All Files", "*"
-        static std::optional<std::string> saveFile(const std::pair<std::string, std::string> &filter);
+        static std::string openFile(const std::pair<std::string, std::string> &filter); // "All Files", "*"
+        static std::string saveFile(const std::pair<std::string, std::string> &filter);
     };
 
 } // namespace Quasar

--- a/QuasarEditor/src/EditorLayer.cpp
+++ b/QuasarEditor/src/EditorLayer.cpp
@@ -449,22 +449,22 @@ namespace Quasar
 
     void EditorLayer::openScene() 
     {
-        std::optional<std::string> filepath = FileDialogs::openFile({ "Quasar Scenes (*.qscene)", "*.qscene" });
-        if (filepath)
+        std::string filepath = FileDialogs::openFile({ "Quasar Scenes (*.qscene)", "*.qscene" });
+        if (!filepath.empty())
         {
             startNewScene();
             SceneSerializer serializer(m_ActiveScene);
-            serializer.deserializeFromText(filepath.value());
+            serializer.deserializeFromText(filepath);
         }
     }
 
     void EditorLayer::saveSceneAs() 
     {
-        std::optional<std::string> filepath = FileDialogs::saveFile({ "Quasar Scenes (*.qscene)", "*.qscene" });
-        if (filepath)
+        std::string filepath = FileDialogs::saveFile({ "Quasar Scenes (*.qscene)", "*.qscene" });
+        if (!filepath.empty())
         {
             SceneSerializer serializer(m_ActiveScene);
-            serializer.serializeToText(filepath.value());
+            serializer.serializeToText(filepath);
         }
     }
 


### PR DESCRIPTION
Finally tried to compile and run on Windows, but a couple of things did
not work. Made the following changes in order for it to work:
* Used cmake's CMAKE_COMMAND -E copy_directory in order to copy the
assets folder into the bin dir instead of Windows' copy command.
* Used a cast operator within the OpenGLRendererAPI debug message call.
* Used explicit conversion from std::filesystem::path to std::string,
since there doesn't seem to be one on Windows.
* Updated ImGuizmo's codebase by pulling from upstream, since it was broken on Windows.
* Removed the usage of std::optional from the FileDialogs, since
including it was creating a weird constexpr error. TODO: look into that,
because the error was very weird.